### PR TITLE
Make sure methods are applied even if a given object instance have a prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Return a new stamp that encapsulates combined behavior. If nothing is passed in,
 
 ### Stamp
 
-* `stamp(baseObject, args...) => objectInstance` **Creates object instances.** Take a base object and any number of arguments. Return the mutated `baseObject` instance back. If no first argument is passed, it uses a new empty object as the base object. Stamps with function or array base objects should not extend the built-in prototypes for `Object` or `Array`.
+* `stamp(baseObject, args...) => objectInstance` **Creates object instances.** Take a base object and any number of arguments. Return the mutated `baseObject` instance back. If no first argument is passed, it uses a new empty object as the base object. If present an existing prototype of the base object must not be mutated. Instead, the behavior (methods) must be added to the base object itself.
  * `.compose(stampsOrDescriptors...) => stamp` **Creates stamps.** *A method exposed by all composables (i.e., stamps)* identical to `compose()`, except it prepends `this` to the stamp parameters. Stamp descriptor properties are attached to the `.compose` method., i.e. `stamp.compose.*`
 
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ const combinedComposables = composable0.compose(composable1, composable2, compos
 
 ### Descriptor
 
-**Composable descriptor** (or just **Descriptor**) is a meta data object. It's a collection of properties that contain the information necessary to create an object instance by a *composable*.
+**Composable descriptor** (or just **Descriptor**) is a meta data object. It's a collection of properties that contain
+the information necessary to create an object instance by a *composable*.
 
 ### Stamp
 
@@ -35,6 +36,7 @@ const combinedComposables = composable0.compose(composable1, composable2, compos
 * *Thenable* ~ *Composable*.
 * `.then` ~ `.compose`.
 * *Promise* ~ *Stamp*.
+* `new Promise(resolve, reject)` ~ `compose(...stamps)`
 
 -----
 
@@ -44,25 +46,35 @@ New stamps can be created by calling a standalone `compose()` function.
 
 ### Standalone `compose()` function
 
-* `compose(stampsOrDescriptors...) => stamp` **Creates stamps.** Take any number of stamps or descriptors. Return a new stamp that encapsulates combined behavior. If nothing is passed in, it returns an empty stamp.
+* `compose(stampsOrDescriptors...) => stamp` **Creates stamps.** Take any number of stamps or descriptors.
+Return a new stamp that encapsulates combined behavior. If nothing is passed in, it returns an empty stamp.
 
 ### Stamp
 
-* `stamp(baseObject, args...) => objectInstance` **Creates object instances.** Take a base object and any number of arguments. Return the mutated `baseObject` instance back. If no first argument is passed, it uses a new empty object as the base object. Stamps with function or array base objects should not extend the built-in prototypes for `Object` or `Array`.
- * `.compose(stampsOrDescriptors...) => stamp` **Creates stamps.** *a method exposed by all composables (i.e., stamps)* identical to `compose()`, except it prepends `this` to the stamp parameters. Stamp descriptor properties are attached to the `.compose` method., i.e. `stamp.compose.*`
+* `stamp(baseObject, args...) => objectInstance` **Creates object instances.**
+Take a base object and any number of arguments. Return the mutated `baseObject` instance back.
+If no first argument is passed, it uses a new empty object as the base object.
+Stamps with function or array base objects should not extend the built-in prototypes for `Object` or `Array`.
+  * `.compose(stampsOrDescriptors...) => stamp` **Creates stamps.** *a method exposed by all composables (i.e., stamps)*
+    identical to `compose()`, except it prepends `this` to the stamp parameters.
+    Stamp descriptor properties are attached to the `.compose` method., i.e. `stamp.compose.*`
 
 
 ## The Stamp Descriptor
 
-The names and definitions of the fixed properties that form the stamp descriptor. The stamp descriptor properties are made available on each stamp as `stamp.compose.*`
+The names and definitions of the fixed properties that form the stamp descriptor.
+The stamp descriptor properties are made available on each stamp as `stamp.compose.*`
 
 * `methods` - A set of methods that will be added to the object's delegate prototype.
 * `properties` - A set of properties that will be added to new object instances by assignment.
 * `deepProperties` - A set of properties that will be added to new object instances by assignment with deep property merge.
 * `initializers` - A set of functions that will run in sequence and passed the data necessary to initialize a stamp instance.
 * `staticProperties` - A set of static properties that will be copied by assignment to the stamp.
-* `propertyDescriptors` - A set of [object property descriptors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties) used for fine-grained control over object property behaviors
-* `configuration` - A set of options made available to the stamp and its initializers during object instance creation. Configuration properties get deep merged.
+* `propertyDescriptors` - A set of [object property
+ descriptors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties)
+  used for fine-grained control over object property behaviors
+* `configuration` - A set of options made available to the stamp and its initializers during object instance creation.
+ Configuration properties get deep merged.
 
 #### Composing descriptors
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ const combinedComposables = composable0.compose(composable1, composable2, compos
 
 ### Descriptor
 
-**Composable descriptor** (or just **Descriptor**) is a meta data object. It's a collection of properties that contain
-the information necessary to create an object instance by a *composable*.
+**Composable descriptor** (or just **Descriptor**) is a meta data object. It's a collection of properties that contain the information necessary to create an object instance by a *composable*.
 
 ### Stamp
 
@@ -46,35 +45,25 @@ New stamps can be created by calling a standalone `compose()` function.
 
 ### Standalone `compose()` function
 
-* `compose(stampsOrDescriptors...) => stamp` **Creates stamps.** Take any number of stamps or descriptors.
-Return a new stamp that encapsulates combined behavior. If nothing is passed in, it returns an empty stamp.
+* `compose(stampsOrDescriptors...) => stamp` **Creates stamps.** Take any number of stamps or descriptors. Return a new stamp that encapsulates combined behavior. If nothing is passed in, it returns an empty stamp.
 
 ### Stamp
 
-* `stamp(baseObject, args...) => objectInstance` **Creates object instances.**
-Take a base object and any number of arguments. Return the mutated `baseObject` instance back.
-If no first argument is passed, it uses a new empty object as the base object.
-Stamps with function or array base objects should not extend the built-in prototypes for `Object` or `Array`.
-  * `.compose(stampsOrDescriptors...) => stamp` **Creates stamps.** *a method exposed by all composables (i.e., stamps)*
-    identical to `compose()`, except it prepends `this` to the stamp parameters.
-    Stamp descriptor properties are attached to the `.compose` method., i.e. `stamp.compose.*`
+* `stamp(baseObject, args...) => objectInstance` **Creates object instances.** Take a base object and any number of arguments. Return the mutated `baseObject` instance back. If no first argument is passed, it uses a new empty object as the base object. Stamps with function or array base objects should not extend the built-in prototypes for `Object` or `Array`.
+ * `.compose(stampsOrDescriptors...) => stamp` **Creates stamps.** *A method exposed by all composables (i.e., stamps)* identical to `compose()`, except it prepends `this` to the stamp parameters. Stamp descriptor properties are attached to the `.compose` method., i.e. `stamp.compose.*`
 
 
 ## The Stamp Descriptor
 
-The names and definitions of the fixed properties that form the stamp descriptor.
-The stamp descriptor properties are made available on each stamp as `stamp.compose.*`
+The names and definitions of the fixed properties that form the stamp descriptor. The stamp descriptor properties are made available on each stamp as `stamp.compose.*`
 
 * `methods` - A set of methods that will be added to the object's delegate prototype.
 * `properties` - A set of properties that will be added to new object instances by assignment.
 * `deepProperties` - A set of properties that will be added to new object instances by assignment with deep property merge.
 * `initializers` - A set of functions that will run in sequence and passed the data necessary to initialize a stamp instance.
 * `staticProperties` - A set of static properties that will be copied by assignment to the stamp.
-* `propertyDescriptors` - A set of [object property
- descriptors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties)
-  used for fine-grained control over object property behaviors
-* `configuration` - A set of options made available to the stamp and its initializers during object instance creation.
- Configuration properties get deep merged.
+* `propertyDescriptors` - A set of [object property descriptors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties) used for fine-grained control over object property behaviors
+* `configuration` - A set of options made available to the stamp and its initializers during object instance creation. Configuration properties get deep merged.
 
 #### Composing descriptors
 

--- a/sample-implementation.js
+++ b/sample-implementation.js
@@ -57,11 +57,11 @@ function stamp(descriptor) {
         // Replacing the prototype of the given instance if there are methods in this descriptor.
         if (!_.isEmpty(descriptor.methods)) {
           // Also we should not change any existing prototypes of any existing methods.
-          if (Object.getPrototypeOf(instance) === Object.prototype) {
-            instance.__proto__ = descriptor.methods;
+          if (Object.getPrototypeOf(context) === Object.prototype) {
+            context.__proto__ = descriptor.methods;
           } else {
             // The given instance already has a prototype. Thus we assign methods straight into the instance.
-            _.assign(instance, descriptor.methods);
+            _.assign(context, descriptor.methods);
           }
         }
       }


### PR DESCRIPTION
README.md - consmentic readability changes.

A somewhat importan change were made to the sample implementation.

If a stamp receives an object which already have non-default prototype then we assign the `methods` straing to the instance. See line 64.

Example:
```js
const MyStamp = compose({ methods: { myMethod(){} } });
MyStamp(new EventEmitter()).myMethod(); // WILL NOT THROW NOW
```