### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Descriptors are composed together to create new descriptors with the following r
 * `deepProperties` are deep merged: `descriptor.deepProperties = _.merge({}, descriptor1.deepProperties, descriptor2.deepProperties)`
 * `initializers` are appended: `descriptor.initializers = descriptor1.initializers.concat(descriptor2.initializers)`
 * `staticProperties` are copied by assignment: `descriptor.staticProperties = _.assign({}, descriptor1.staticProperties, descriptor2.staticProperties)`
-* `propertyDescriptors` are deep merged: `descriptor.propertyDescriptors = _.merge({}, descriptor1.propertyDescriptors, descriptor2.propertyDescriptors)`
-* `staticPropertyDescriptors` are deep merged: `descriptor.propertyDescriptors = _.merge({}, descriptor1.propertyDescriptors, descriptor2.propertyDescriptors)`
+* `propertyDescriptors` are copied by assignment: `descriptor.propertyDescriptors = _.assign({}, descriptor1.propertyDescriptors, descriptor2.propertyDescriptors)`
+* `staticPropertyDescriptors` are copied by assignment: `descriptor.propertyDescriptors = _.assign({}, descriptor1.propertyDescriptors, descriptor2.propertyDescriptors)`
 * `configuration` are deep merged: `descriptor.configuration = _.merge({}, descriptor1.configuration, descriptor2.configuration)`
 
 


### PR DESCRIPTION
I have a gut feeling that conflicting property descriptors should work like overrides rather than merges. If a stamp is altering the descriptor, it's doing so for a reason. If another stamp is altering it in a different way, it's likely to break the intended behavior of the first anyway, so shouldn't it override?