### PR TITLE
[#35, #37] Remove `instance` behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ const myStamp = compose(config, warnOnCollisions);
 
 ### Stamp Options
 
-It is recommended that stamp factories only take one argument: The stamp `options` argument. There are no reserved properties and no special meaning. However, using multiple arguments for a stamp could create conflicts where multiple stamps expect the same argument to mean different things. Using named parameters, it's possible for stamp creator to resolve conflicts with `options` namespacing. For example, if you want to compose a database connection stamp with a message queue stamp:
+It is recommended that stamps only take one argument: The stamp `options` argument. There are no reserved properties and no special meaning. However, using multiple arguments for a stamp could create conflicts where multiple stamps expect the same argument to mean different things. Using named parameters, it's possible for stamp creator to resolve conflicts with `options` namespacing. For example, if you want to compose a database connection stamp with a message queue stamp:
 
 ```js
 const db = dbStamp({

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ const myStamp = compose(config, warnOnCollisions);
 
 ### Stamp Options
 
-It is recommended that stamp initializers only use one argument: The stamp `options` argument. There are no reserved properties and no special meaning. However, using multiple arguments for a stamp could create conflicts where multiple stamps expect the same argument to mean different things. Using named parameters, it's possible for stamp creator to resolve conflicts with `options` namespacing. For example, if you want to compose a database connection stamp with a message queue stamp:
+It is recommended that stamp factories only take one argument: The stamp `options` argument. There are no reserved properties and no special meaning. However, using multiple arguments for a stamp could create conflicts where multiple stamps expect the same argument to mean different things. Using named parameters, it's possible for stamp creator to resolve conflicts with `options` namespacing. For example, if you want to compose a database connection stamp with a message queue stamp:
 
 ```js
 const db = dbStamp({

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Initializers have the following signature:
 ```
 
 * `options` The `options` argument passed into the stamp, containing propreties that may be used by initializers.
-* `instance` The object instance being produced by the stamp. If the initializer returns a new object, it replaces the instance for subsequent initializer calls.
+* `instance` The object instance being produced by the stamp. If the initializer returns a different object, it replaces the instance.
 * `stamp` A reference to the stamp producing the instance.
 * `args` An array of the arguments passed into the stamp, including the `options` argument.
 


### PR DESCRIPTION
Discussions in #35 and #37:

Since it would be trivial to implement `instance` mutation as a stamp, it makes sense to strip it from the stamp spec to simplify things and eliminate any need for reserved properties.

I believe it's still a very good idea to encourage the use of a single `options` object, so that will remain part of the spec.