### PR TITLE
Fix all tests to create composables as function objects not POJO.

### DIFF
--- a/test/assignment-tests.js
+++ b/test/assignment-tests.js
@@ -10,16 +10,17 @@ const assignmentProps = [
 ];
 
 const build = (num) => {
-  const composable = {};
+  const composable = function(){};
+  composable.compose = function(){};
 
   assignmentProps.forEach(prop => {
-    composable[prop] = {
+    composable.compose[prop] = {
       [num]: num,
       override: num
     };
   });
 
-  return { compose: composable };
+  return composable;
 };
 
 // Loop over each property that is copied by assignment and ensure

--- a/test/initializer-tests.js
+++ b/test/initializer-tests.js
@@ -4,39 +4,38 @@ import compose from '../examples/compose';
 
 const build = (num) => {
 
-  const composable = {
-    initializers: [() => {
-      return { num };
-    }]
-  };
+  const composable = function () {};
+  composable.compose = function () {};
+  composable.compose.initializers = [() => {
+    return {num};
+  }];
 
-  return { compose: composable };
+  return composable;
 };
 
 const buildInitializers = () => {
 
-  return {
-    compose: {
-      initializers: [
-        (args, { instance }) => {
-          return Object.assign(instance, {
-            a: 'a',
-            override: 'a'
-          });
-        },
-        (args, { instance }) => {
-          return Object.assign(instance, {
-            b: 'b'
-          });
-        },
-        (args, { instance }) => {
-          return Object.assign(instance, {
-            override: 'c'
-          });
-        }
-      ]
+  const composable = function () {};
+  composable.compose = function () {};
+  composable.compose.initializers = [
+    (args, { instance }) => {
+      return Object.assign(instance, {
+        a: 'a',
+        override: 'a'
+      });
+    },
+    (args, { instance }) => {
+      return Object.assign(instance, {
+        b: 'b'
+      });
+    },
+    (args, { instance }) => {
+      return Object.assign(instance, {
+        override: 'c'
+      });
     }
-  };
+  ];
+  return composable;
 };
 
 
@@ -85,37 +84,36 @@ test('compose()', nest => {
 test('stamp()', nest => {
 
   nest.test('...with initializers', assert => {
-    const testStamp = compose({
-      compose: {
-        properties: {
-          'instanceProps': true
-        },
-        initializers: [
-          function ({ stampOption }, { instance, stamp }) {
-            const actual = {
-              correctThisValue: this === instance,
-              hasOptions: Boolean(stampOption),
-              hasInstance: Boolean(instance.instanceProps),
-              hasStamp: Boolean(stamp.compose)
-            };
+    const composable = function(){};
+    composable.compose = function(){};
+    composable.compose.properties = {
+      'instanceProps': true
+    };
+    composable.compose.initializers = [
+      function ({ stampOption }, { instance, stamp }) {
+        const actual = {
+          correctThisValue: this === instance,
+          hasOptions: Boolean(stampOption),
+          hasInstance: Boolean(instance.instanceProps),
+          hasStamp: Boolean(stamp.compose)
+        };
 
-            const expected = {
-              correctThisValue: true,
-              hasOptions: true,
-              hasInstance: true,
-              hasStamp: true
-            };
+        const expected = {
+          correctThisValue: true,
+          hasOptions: true,
+          hasInstance: true,
+          hasStamp: true
+        };
 
-            assert.deepEqual(actual, expected,
-              'should call initializer with correct signature');
+        assert.deepEqual(actual, expected,
+          'should call initializer with correct signature');
 
-            assert.end();
-          }
-        ]
+        assert.end();
       }
-    });
+    ];
+    const testStamp = compose(composable);
 
-    testStamp({ stampOption: true });
+    testStamp({stampOption: true});
   });
 
   nest.test('...with initializers', assert => {
@@ -135,17 +133,16 @@ test('stamp()', nest => {
   });
 
   nest.test('...with `this` in initializer', assert => {
-    const stamp = compose({
-      compose: {
-        initializers: [
-          function () {
-            return Object.assign(this, {
-              a: 'a'
-            });
-          }
-        ]
+    const composable = function(){};
+    composable.compose = function(){};
+    composable.compose.initializers = [
+      function () {
+        return Object.assign(this, {
+          a: 'a'
+        });
       }
-    });
+    ];
+    const stamp = compose(composable);
 
     const actual = compose(stamp)();
     const expected = {

--- a/test/merge-tests.js
+++ b/test/merge-tests.js
@@ -9,10 +9,11 @@ const mergeProps = [
 
 
 const build = (num) => {
-  const composable = {};
+  const composable = function(){};
+  composable.compose = function(){};
 
   mergeProps.forEach(prop => {
-    composable[prop] = {
+    composable.compose[prop] = {
       a: {
         [num]: num,
         merge: {
@@ -22,7 +23,7 @@ const build = (num) => {
     };
   });
 
-  return { compose: composable };
+  return composable;
 };
 
 test('Deep property merge', nest => {

--- a/test/stamp-tests.js
+++ b/test/stamp-tests.js
@@ -2,13 +2,14 @@ import test from 'tape';
 import compose from '../examples/compose';
 
 const build = (prop, key, val = key) => {
-  const composable = {};
+  const composable = function(){};
+  composable.compose = function(){};
 
-  composable[prop] = {
+  composable.compose[prop] = {
     [val]: val
   };
 
-  return { compose: composable };
+  return composable;
 };
 
 test('compose()', assert => {
@@ -36,12 +37,13 @@ test('Stamp', nest => {
 
 test('Stamp assignments', nest => {
   nest.test('...with properties', assert => {
-    const stamp = compose({compose: {
-      properties: {
-        a: 'a',
-        b: 'b'
-      }
-    }});
+    const composable = function(){};
+    composable.compose = function(){};
+    composable.compose.properties = {
+      a: 'a',
+      b: 'b'
+    };
+    const stamp = compose(composable);
 
     const actual = stamp();
     const expected = {


### PR DESCRIPTION
stampit v3 is doing stricter checks on what a composable is. It is checking that both stamps and its descriptors are function objects, not just POJO.

So, this PR makes sure that the tests follow specs stricter.