### PR TITLE
Properties on descriptors are optional to exist

### DIFF
--- a/test/compose-basic-tests.js
+++ b/test/compose-basic-tests.js
@@ -11,43 +11,6 @@ test('compose function', assert => {
   assert.end();
 });
 
-test('compose() descriptor creation', assert => {
-  const descriptorPropNames = [
-    'methods',
-    'properties',
-    'deepProperties',
-    'staticProperties',
-    'deepStaticProperties',
-    'propertyDescriptors',
-    'staticPropertyDescriptors',
-    'configuration',
-    'initializers'
-  ];
-
-  const stamp = compose();
-
-  const actual = () => {
-    const obj = {};
-    descriptorPropNames.forEach(propName => {
-      obj[ propName + ' exists'] = Boolean(stamp.compose[propName]);
-    });
-    return obj;
-  }();
-
-  const expected = () => {
-    const obj = {};
-    descriptorPropNames.forEach(propName => {
-      obj[ propName + ' exists'] = true;
-    });
-    return obj;
-  }();
-
-  assert.deepEqual(actual, expected,
-    'All descriptor properties should be added to stamp descriptor');
-
-  assert.end();
-});
-
 test('compose.staticProperties', nest => {
   ['staticProperties', 'deepStaticProperties'].forEach(descriptorName => {
 


### PR DESCRIPTION
I know Eric spent time on this, but specs do not demand presence of all descriptor properties. So as tests should not.

My opinion is strong. Too many useless empty objects will degrade any application performance.