### PR TITLE
Update initializer test to check if `args` is present.

### DIFF
--- a/examples/compose.js
+++ b/examples/compose.js
@@ -15,17 +15,16 @@ const createStamp = ({
 
   const assign = Object.assign;
 
-  const Stamp = function Stamp (...args) {
+  const Stamp = function Stamp (options, ...args) {
     let obj = Object.create(methods);
 
     assign(obj, deepProperties, properties);
 
     Object.defineProperties(obj, propertyDescriptors);
 
-    const options = args[0];
     initializers.forEach(initializer => {
       const returnValue = initializer.call(obj, options,
-        { instance: obj, stamp: Stamp, args });
+        { instance: obj, stamp: Stamp, args: [options].concat(args) });
       if ( returnValue ) {
         obj = returnValue;
       }

--- a/examples/compose.js
+++ b/examples/compose.js
@@ -15,16 +15,17 @@ const createStamp = ({
 
   const assign = Object.assign;
 
-  const Stamp = function Stamp (options = {}) {
+  const Stamp = function Stamp (...args) {
     let obj = Object.create(methods);
 
     assign(obj, deepProperties, properties);
 
     Object.defineProperties(obj, propertyDescriptors);
 
+    const options = args[0];
     initializers.forEach(initializer => {
       const returnValue = initializer.call(obj, options,
-        { instance: obj, stamp: Stamp });
+        { instance: obj, stamp: Stamp, args });
       if ( returnValue ) {
         obj = returnValue;
       }

--- a/test/initializer-tests.js
+++ b/test/initializer-tests.js
@@ -118,7 +118,7 @@ test('stamp()', nest => {
     testStamp({stampOption: true}, 1, 2);
   });
 
-  nest.test('...with initializers', assert => {
+  nest.test('...with overrides in initializer', assert => {
     const stamp = buildInitializers();
 
     const actual = compose(stamp)();
@@ -132,6 +132,24 @@ test('stamp()', nest => {
       'should apply initializers with last-in priority');
 
     assert.end();
+  });
+
+  nest.test('...with args in initializer', assert => {
+    const expected = [0, "string", { obj: {} }, [1, 2, 3]];
+
+    const composable = function(){};
+    composable.compose = function(){};
+    composable.compose.initializers = [
+      function (options, { args }) {
+        assert.deepEqual(args, expected,
+          'should receive all given arguments');
+
+        assert.end();
+      }
+    ];
+    const testStamp = compose(composable);
+
+    testStamp(expected[0], expected[1], expected[2], expected[3]);
   });
 
   nest.test('...with `this` in initializer', assert => {


### PR DESCRIPTION
Implements #46.