### PR TITLE
Do not insist on 'descriptor.intializers' array creation.

### DIFF
--- a/test/initializer-tests.js
+++ b/test/initializer-tests.js
@@ -45,10 +45,7 @@ test('compose()', nest => {
     const subject = compose({ initializers: [ 0, 'a', null, undefined, {}, NaN, /regexp/ ]});
     const initializers = subject.compose.initializers;
 
-    const actual = initializers.length;
-    const expected = 0;
-
-    assert.equal(actual, expected,
+    assert.notOk(initializers && initializers.length,
       'should not add any initializers');
 
     assert.end();


### PR DESCRIPTION
Relax the test. Do not insist of empty array creation when no initializers are present at a stamp.