### PR TITLE
Getting ready for publishing to NPM

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -152,7 +152,6 @@
     "no-void": [0],
     "no-warning-comments": [0, {"terms": ["todo", "fixme", "xxx"], "location": "start"}],
     "no-with": [2],
-    "no-extra-parens": [2],
     "one-var": [0],
     "operator-assignment": [0, "always"],
     "operator-linebreak": [2, "after"],
@@ -163,7 +162,7 @@
     "semi-spacing": [2, {"before": false, "after": true}],
     "sort-vars": [0],
     "space-after-keywords": [2, "always"],
-    "space-before-function-paren": [2, {"anonymous": "always", "named": "always"}],
+    "space-before-function-paren": [2, {"anonymous": "always", "named": "never"}],
     "space-before-blocks": [0, "always"],
     "space-in-brackets": [
       0, "never", {

--- a/examples/compose.js
+++ b/examples/compose.js
@@ -1,70 +1,73 @@
 import merge from 'lodash/merge';
-const isFunction = (obj) => typeof obj === 'function';
 const assign = Object.assign;
-
-const getDescriptorProps = (descriptorName, composables) => {
-  return !composables ? undefined : composables.map(composable => {
-    const descriptor = composable.compose || composable;
-    return descriptor[descriptorName];
-  });
-};
+const isFunction = obj => typeof obj === 'function';
+const isObject = obj => !!obj && (typeof obj === 'function' || typeof obj === 'object');
+const isDescriptor = obj => isObject(obj);
 
 const createStamp = (composeMethod) => {
   const {
     methods, properties, deepProperties, propertyDescriptors, initializers,
     staticProperties, deepStaticProperties, staticPropertyDescriptors
-  } = composeMethod;
+    } = composeMethod;
 
   const Stamp = function Stamp(options, ...args) {
-    let obj = Object.create(methods);
+    let obj = Object.create(methods || {});
 
     merge(obj, deepProperties);
     assign(obj, properties);
 
-    Object.defineProperties(obj, propertyDescriptors);
+    if (propertyDescriptors) Object.defineProperties(obj, propertyDescriptors);
 
-    initializers.forEach(initializer => {
-      const returnValue = initializer.call(obj, options,
-        { instance: obj, stamp: Stamp, args: [options].concat(args) });
-      if (returnValue !== undefined) {
-        obj = returnValue;
-      }
-    });
+    if (Array.isArray(initializers)) {
+      initializers.forEach(initializer => {
+        const returnValue = initializer.call(obj, options,
+          {instance: obj, stamp: Stamp, args: [options].concat(args)});
+        if (returnValue !== undefined) {
+          obj = returnValue;
+        }
+      });
+    }
 
     return obj;
   };
 
   merge(Stamp, deepStaticProperties);
   assign(Stamp, staticProperties);
-  Object.defineProperties(Stamp, staticPropertyDescriptors);
+  if (staticPropertyDescriptors) Object.defineProperties(Stamp, staticPropertyDescriptors);
   Stamp.compose = composeMethod;
 
   return Stamp;
 };
 
+function mergeInComposable(dstDescriptor, src) {
+  const srcDescriptor = (src && src.compose) || src;
+  if (!isDescriptor(srcDescriptor)) return dstDescriptor;
 
-function compose (...composables) {
-  const composeMethod = function (...args) {
+  const combineDescriptorProperty = (propName, action) => {
+    if (!isObject(srcDescriptor[propName])) return;
+    if (!isObject(dstDescriptor[propName])) dstDescriptor[propName] = {};
+    action(dstDescriptor[propName], srcDescriptor[propName]);
+  };
+
+  combineDescriptorProperty('methods', assign);
+  combineDescriptorProperty('properties', assign);
+  combineDescriptorProperty('deepProperties', merge);
+  combineDescriptorProperty('staticProperties', assign);
+  combineDescriptorProperty('deepStaticProperties', merge);
+  combineDescriptorProperty('propertyDescriptors', assign);
+  combineDescriptorProperty('staticPropertyDescriptors', assign);
+  combineDescriptorProperty('configuration', merge);
+  dstDescriptor.initializers = [].concat(dstDescriptor.initializers, srcDescriptor.initializers).filter(isFunction);
+
+  return dstDescriptor;
+}
+
+function compose(...composables) {
+  let composeMethod = function (...args) {
     return compose(composeMethod, ...args);
   };
 
-  assign(composeMethod, {
-    methods: assign({}, ...getDescriptorProps('methods', composables)),
-    deepProperties: merge({},
-      ...getDescriptorProps('deepProperties', composables)),
-    properties: assign({}, ...getDescriptorProps('properties', composables)),
-    deepStaticProperties: merge({},
-      ...getDescriptorProps('deepStaticProperties', composables)),
-    staticProperties: assign({},
-      ...getDescriptorProps('staticProperties', composables)),
-    propertyDescriptors: assign({},
-      ...getDescriptorProps('propertyDescriptors', composables)),
-    staticPropertyDescriptors: assign({},
-      ...getDescriptorProps('staticPropertyDescriptors', composables)),
-    initializers: [].concat(...getDescriptorProps('initializers', composables))
-      .filter(isFunction),
-    configuration: merge({}, ...getDescriptorProps('configuration', composables))
-  });
+  composeMethod = composables.reduce(mergeInComposable, composeMethod);
 
   return createStamp(composeMethod);
 }

--- a/examples/compose.js
+++ b/examples/compose.js
@@ -2,7 +2,7 @@ import merge from 'lodash/merge';
 const assign = Object.assign;
 const isFunction = obj => typeof obj === 'function';
 const isObject = obj => !!obj && (typeof obj === 'function' || typeof obj === 'object');
-const isDescriptor = obj => isObject(obj);
+const isDescriptor = isObject;
 
 const createStamp = (composeMethod) => {
   const {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "stamp-specification",
   "version": "1.0.0-beta",
-  "description": "The Composables specification",
-  "main": "index.js",
+  "description": "The Composables specification and example implementation",
+  "main": "build/index.js",
   "scripts": {
+    "build": "babel -s -d build examples",
     "lint": "eslint examples && eslint test",
-    "test": "babel-node test/index.js",
-    "watch": "watch 'clear && npm run -s lint && npm -s test' test/ examples/"
+    "test": "tape -r babel/register test/index.js",
+    "watch": "watch 'clear && npm run -s lint && npm -s test' test/ examples/",
+    "prepublish": "npm run lint && npm run test && npm run build"
   },
   "repository": {
     "type": "git",

--- a/test/compose-basic-tests.js
+++ b/test/compose-basic-tests.js
@@ -14,7 +14,7 @@ test('compose function', assert => {
 test('compose.staticProperties', nest => {
   ['staticProperties', 'deepStaticProperties'].forEach(descriptorName => {
 
-    nest.test('...for descriptor', assert => {
+    nest.test(`...for descriptor with ${descriptorName}`, assert => {
       const actual = compose({
         [ descriptorName ]: {
           a: 'a'
@@ -36,7 +36,7 @@ test('compose.staticProperties', nest => {
       assert.end();
     });
 
-    nest.test('...for stamp', assert => {
+    nest.test(`...for stamp with ${descriptorName}`, assert => {
       const stamp = compose({
         [ descriptorName ]: {
           a: 'a'

--- a/test/compose-tests.js
+++ b/test/compose-tests.js
@@ -1,0 +1,13 @@
+import test from 'tape';
+import _ from 'lodash';
+import compose from '../examples/compose';
+
+test('compose ignores non objects', assert => {
+  const stamp = compose(0, 'a', null, undefined, {}, NaN, /regexp/);
+  const subject = _.values(stamp.compose).filter(value => !_.isEmpty(value)).length;
+
+  assert.equal(subject, 0,
+    'should not add any descriptor data');
+
+  assert.end();
+});

--- a/test/compose-tests.js
+++ b/test/compose-tests.js
@@ -5,8 +5,9 @@ import compose from '../examples/compose';
 test('compose ignores non objects', assert => {
   const stamp = compose(0, 'a', null, undefined, {}, NaN, /regexp/);
   const subject = _.values(stamp.compose).filter(value => !_.isEmpty(value)).length;
+  const expected = 0;
 
-  assert.equal(subject, 0,
+  assert.equal(subject, expected,
     'should not add any descriptor data');
 
   assert.end();

--- a/test/descriptor-tests.js
+++ b/test/descriptor-tests.js
@@ -22,8 +22,8 @@ test('comopose function pojo (Plain Old JavaScript Object)', nest => {
         }
       };
 
-      const actual = compose(descriptor).compose[ descriptorName ].a;
-      const expected = { b: 'b' };
+      const actual = compose(descriptor).compose[descriptorName].a;
+      const expected = {b: 'b'};
 
       assert.deepEqual(actual, expected,
         `should create ${ descriptorName } descriptor`);
@@ -37,15 +37,15 @@ test('comopose function pojo (Plain Old JavaScript Object)', nest => {
 test('compose function pojo', nest => {
 
   nest.test('...with pojo descriptor.methods', assert => {
-    const a = function a () {
+    const a = function a() {
       return 'a';
     };
 
     const actual = Object.getPrototypeOf(compose({
-      methods: { a }
+      methods: {a}
     })());
 
-    const expected = { a };
+    const expected = {a};
 
     assert.deepEqual(actual, expected,
       'should create methods descriptor');
@@ -54,15 +54,15 @@ test('compose function pojo', nest => {
   });
 
   nest.test('...with pojo descriptor.initializers', assert => {
-    const a = function a () {
+    const a = function a() {
       return 'a';
     };
 
     const actual = compose({
-      initializers: [ a ]
+      initializers: [a]
     }).compose.initializers;
 
-    const expected = [ a ];
+    const expected = [a];
 
     assert.deepEqual(actual, expected,
       'should create initializers descriptor');

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 import './assignment-tests';
 import './compose-basic-tests';
+import './compose-tests';
 import './descriptor-tests';
 import './initializer-tests';
 import './merge-tests';

--- a/test/property-descriptor-tests.js
+++ b/test/property-descriptor-tests.js
@@ -1,4 +1,5 @@
 import test from 'tape';
+import _ from 'lodash';
 import compose from '../examples/compose';
 
 const createDescriptors = () => {
@@ -30,6 +31,35 @@ test('stamp', nest => {
 
     assert.deepEqual(actual, expected,
       'should assign propertyDescriptors to instances');
+
+    assert.end();
+  });
+
+  nest.test('...with malformed propertyDescriptors', assert => {
+    [0, 'a', null, undefined, {}, NaN, /regexp/].forEach(propertyValue => {
+      const actual = compose({
+        propertyDescriptors: propertyValue
+      })();
+      const expected = {};
+
+      assert.deepEqual(actual, expected,
+        'should not any properties instances');
+    });
+
+    assert.end();
+  });
+
+  nest.test('...with malformed staticPropertyDescriptors', assert => {
+    [0, 'a', null, undefined, {}, NaN, /regexp/].forEach(propertyValue => {
+      const stamp = compose({
+        staticPropertyDescriptors: propertyValue
+      });
+      const actual = _.values(stamp.compose).filter(value => !_.isEmpty(value)).length;
+      const expected = 0;
+
+      assert.equal(actual, expected,
+        'should not add any descriptor data');
+    });
 
     assert.end();
   });


### PR DESCRIPTION
* Move descriptor merging logic to a separate function for readability.
* Merge descriptors one by one into the final descriptor.
* Allow descriptor properties to be missing or even malformed.
* Few more tests

Also, this PR open a road to #63 and/or #66.