### PR TITLE
Avoid empty array of initializers after each compose call.

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -87,7 +87,10 @@ function mergeComposable(dstDescriptor, srcComposable) {
   combineProperty('staticPropertyDescriptors', assign);
   combineProperty('configuration', assign);
   combineProperty('deepConfiguration', merge);
-  dstDescriptor.initializers = [].concat(dstDescriptor.initializers, srcDescriptor.initializers).filter(isFunction);
+  if (Array.isArray(srcDescriptor.initializers)) {
+    if (!Array.isArray(dstDescriptor.initializers)) dstDescriptor.initializers = [];
+    dstDescriptor.initializers.push.apply(dstDescriptor.initializers, srcDescriptor.initializers.filter(isFunction));
+  }
 
   return dstDescriptor;
 }


### PR DESCRIPTION
This makes "intializers" property consistent with all other descriptor properties. This means it won't be created if both descriptors didn't have it.