### PR TITLE
Bump version in README to 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Stamp Specification v1.1
+# Stamp Specification v1.2
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/stampit-org/stampit?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Introduction


### PR DESCRIPTION
We should remember if we change the specs we also need to bump the version in the top of the README.