### PR TITLE
Allow late stage stamp metadata editing

### DIFF
--- a/compose.js
+++ b/compose.js
@@ -79,13 +79,13 @@ export function mergeDescriptor(dst, ...srcs) {
 
 /**
  * Creates new factory instance.
- * @param {object} descriptor The information about the object the factory will be creating.
  * @returns {Function} The new factory function.
  */
-function createFactory(descriptor) {
+function createFactory() {
   return function Stamp(options = {}, ...args) {
+    const descriptor = Stamp.compose || {};
     // The 'methods' metadata object becomes the prototype for new object instances.
-    const instance = Object.create(descriptor.methods || {});
+    const instance = Object.create(descriptor.methods || null);
 
     // Deep merge, then override with shallow merged properties, then apply property descriptors.
     merge(instance, descriptor.deepProperties);
@@ -119,7 +119,7 @@ function createFactory(descriptor) {
  * @returns {Stamp}
  */
 function createStamp(descriptor, composeFunction) {
-  const Stamp = createFactory(descriptor);
+  const Stamp = createFactory();
 
   // Deep merge, then override with shallow merged properties, then apply property descriptors.
   merge(Stamp, descriptor.staticDeepProperties);


### PR DESCRIPTION
This fixes an unexpected behavior of late stage stamp editing.

This code executes initializers:
```js
const stamp = compose(Something)
  .compose({ initializers: [function () {
    console.log("I don't want this line executed");
  }]});

delete stamp.compose.initializers; // Don't want!!!

stamp(); // will log to the console
```

After the PR the initializers will not be executed as expected.